### PR TITLE
Gradle 8 compatability

### DIFF
--- a/src/main/groovy/org/web3j/solidity/gradle/plugin/DefaultSoliditySourceSet.groovy
+++ b/src/main/groovy/org/web3j/solidity/gradle/plugin/DefaultSoliditySourceSet.groovy
@@ -15,7 +15,6 @@ package org.web3j.solidity.gradle.plugin
 import groovy.transform.CompileStatic
 import org.gradle.api.Action
 import org.gradle.api.file.SourceDirectorySet
-import org.gradle.api.internal.file.SourceDirectorySetFactory
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.reflect.HasPublicType
 import org.gradle.api.reflect.TypeOf

--- a/src/main/groovy/org/web3j/solidity/gradle/plugin/SolidityPlugin.groovy
+++ b/src/main/groovy/org/web3j/solidity/gradle/plugin/SolidityPlugin.groovy
@@ -86,7 +86,12 @@ class SolidityPlugin implements Plugin<Project> {
         def defaultOutputDir = new File(project.buildDir, "resources/$sourceSet.name/$NAME")
 
         soliditySourceSet.solidity.srcDir(defaultSrcDir)
-        soliditySourceSet.solidity.outputDir = defaultOutputDir
+        try {
+            soliditySourceSet.solidity.destinationDirectory = defaultOutputDir
+        } catch (ReadOnlyPropertyException ignored) {
+            //TODO delete this catch block and unwrap the try block after Gradle 8 migration
+            soliditySourceSet.solidity.outputDir = defaultOutputDir
+        }
 
         sourceSet.allJava.source(soliditySourceSet.solidity)
         sourceSet.allSource.source(soliditySourceSet.solidity)
@@ -122,7 +127,7 @@ class SolidityPlugin implements Plugin<Project> {
         compileTask.evmVersion = project.solidity.evmVersion
         compileTask.allowPaths = project.solidity.allowPaths
         compileTask.ignoreMissing = project.solidity.ignoreMissing
-        compileTask.outputs.dir(soliditySourceSet.solidity.outputDir)
+        compileTask.outputs.dir(soliditySourceSet.solidity.destinationDirectory)
         compileTask.description = "Compiles $sourceSet.name Solidity source."
 
         if (project.solidity.resolvePackages) {

--- a/src/test/groovy/org/web3j/solidity/gradle/plugin/SolidityPluginTest.groovy
+++ b/src/test/groovy/org/web3j/solidity/gradle/plugin/SolidityPluginTest.groovy
@@ -320,6 +320,8 @@ class SolidityPluginTest {
                     }
                 }
             }
+
+            tasks.named("jar").configure { dependsOn("compileSolidity") }
         """
 
         def success = build()


### PR DESCRIPTION

### What does this PR do?
This applies the essential fixes needed to upgrade to Gradle 8.6 but
continues to use Gradle 7.6 in the plugin build system. This provides
for Gradle 8.x compatability.

### Where should the reviewer start?
These are two small changes focused on the outputDir proeprty and one
fix that will be needed to test with Gradle 8

### Why is it needed?
Without these changes the plugin cannot be used in Gradle 8.x, which
is required for Java 21 support.
