### PR TITLE
Different solidity compile config for different sourceSets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,20 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [0.4.2]() (Upcoming)
+
+### Bug Fixes
+
+* 
+
+### Features
+
+* Different solidity compile config for different sourceSets [#69](https://github.com/hyperledger/web3j-solidity-gradle-plugin/pull/69)
+
+### BREAKING CHANGES
+
+* 
+
 # [0.4.1](https://github.com/web3j/solidity-gradle-plugin/releases/tag/v0.4.1) (2024-05-02)
 
 ### Bug Fixes

--- a/README.md
+++ b/README.md
@@ -85,6 +85,26 @@ sourceSets {
 }
 ```
 
+Now with solidity gradle plugin version 0.4.2, you can set different solidity versions, evmVersions, optimize flag, optimizeRuns and ignoreMissing 
+flag values for different sourceSets.
+
+```groovy
+sourceSets {
+    main {
+        solidity {
+            srcDir {
+                "my/custom/path/to/solidity"
+            }
+            output.resourcesDir = file('out/bin/compiledSol')
+            setEvmVersion('ISTANBUL')
+            setOptimize(true)
+            setOptimizeRuns(200)
+            setVersion('0.8.12')
+        }
+    }
+}
+```
+
 ## Gradle Node Plugin
 
 The plugin makes use of the [Node plugin](https://github.com/node-gradle/gradle-node-plugin) to resolve third-party

--- a/src/main/groovy/org/web3j/solidity/gradle/plugin/DefaultSoliditySourceSet.groovy
+++ b/src/main/groovy/org/web3j/solidity/gradle/plugin/DefaultSoliditySourceSet.groovy
@@ -28,6 +28,7 @@ class DefaultSoliditySourceSet implements SoliditySourceSet, HasPublicType {
 
     private final SourceDirectorySet solidity
     private final SourceDirectorySet allSolidity
+    private EVMVersion evmVersion
 
     DefaultSoliditySourceSet(
             final String displayName,
@@ -66,6 +67,17 @@ class DefaultSoliditySourceSet implements SoliditySourceSet, HasPublicType {
     @Override
     TypeOf<?> getPublicType() {
         return TypeOf.typeOf(SoliditySourceSet.class)
+    }
+
+    // Implementations for evmVersion handling
+    @Override
+    void setEvmVersion(EVMVersion evmVersion) {
+        this.evmVersion =  evmVersion
+    }
+
+    @Override
+    EVMVersion getEvmVersion() {
+        return this.evmVersion
     }
 
 }

--- a/src/main/groovy/org/web3j/solidity/gradle/plugin/DefaultSoliditySourceSet.groovy
+++ b/src/main/groovy/org/web3j/solidity/gradle/plugin/DefaultSoliditySourceSet.groovy
@@ -29,6 +29,10 @@ class DefaultSoliditySourceSet implements SoliditySourceSet, HasPublicType {
     private final SourceDirectorySet solidity
     private final SourceDirectorySet allSolidity
     private EVMVersion evmVersion
+    private String version
+    private Boolean optimize
+    private Integer optimizeRuns
+    private Boolean ignoreMissing
 
     DefaultSoliditySourceSet(
             final String displayName,
@@ -69,7 +73,6 @@ class DefaultSoliditySourceSet implements SoliditySourceSet, HasPublicType {
         return TypeOf.typeOf(SoliditySourceSet.class)
     }
 
-    // Implementations for evmVersion handling
     @Override
     void setEvmVersion(EVMVersion evmVersion) {
         this.evmVersion =  evmVersion
@@ -80,4 +83,43 @@ class DefaultSoliditySourceSet implements SoliditySourceSet, HasPublicType {
         return this.evmVersion
     }
 
+    @Override
+    void setVersion(String version) {
+        this.version =  version
+    }
+
+    @Override
+    String getVersion() {
+        return this.version
+    }
+
+    @Override
+    void setOptimize(Boolean optimize) {
+        this.optimize = optimize
+    }
+
+    @Override
+    Boolean getOptimize() {
+        return this.optimize
+    }
+
+    @Override
+    void setOptimizeRuns(Integer optimizeRuns) {
+        this.optimizeRuns = optimizeRuns
+    }
+
+    @Override
+    Integer getOptimizeRunsn() {
+        return this.optimizeRuns
+    }
+
+    @Override
+    void setIgnoreMissing(Boolean ignoreMissing) {
+        this.ignoreMissing = ignoreMissing
+    }
+
+    @Override
+    Boolean getIgnoreMissing() {
+        return this.ignoreMissing
+    }
 }

--- a/src/main/groovy/org/web3j/solidity/gradle/plugin/SolidityPlugin.groovy
+++ b/src/main/groovy/org/web3j/solidity/gradle/plugin/SolidityPlugin.groovy
@@ -124,8 +124,11 @@ class SolidityPlugin implements Plugin<Project> {
         compileTask.optimize = project.solidity.optimize
         compileTask.optimizeRuns = project.solidity.optimizeRuns
         compileTask.prettyJson = project.solidity.prettyJson
-//        compileTask.evmVersion = project.solidity.${srcSetName}.evmVersion
-        compileTask.evmVersion = soliditySourceSet.getEvmVersion()
+        if (soliditySourceSet.getEvmVersion()){
+            compileTask.evmVersion = soliditySourceSet.getEvmVersion()
+        } else {
+            compileTask.evmVersion = project.solidity.evmVersion
+        }
         compileTask.allowPaths = project.solidity.allowPaths
         compileTask.ignoreMissing = project.solidity.ignoreMissing
         compileTask.outputs.dir(soliditySourceSet.solidity.destinationDirectory)

--- a/src/main/groovy/org/web3j/solidity/gradle/plugin/SolidityPlugin.groovy
+++ b/src/main/groovy/org/web3j/solidity/gradle/plugin/SolidityPlugin.groovy
@@ -116,13 +116,25 @@ class SolidityPlugin implements Plugin<Project> {
             compileTask.executable = project.solidity.executable
         }
         compileTask.pathRemappings = project.solidity.pathRemappings
-        compileTask.version = project.solidity.version
+        if (soliditySourceSet.getVersion()){
+            compileTask.version = soliditySourceSet.getVersion()
+        } else {
+            compileTask.version = project.solidity.version
+        }
         compileTask.source = soliditySourceSet.solidity
         compileTask.outputComponents = project.solidity.outputComponents
         compileTask.combinedOutputComponents = project.solidity.combinedOutputComponents
         compileTask.overwrite = project.solidity.overwrite
-        compileTask.optimize = project.solidity.optimize
-        compileTask.optimizeRuns = project.solidity.optimizeRuns
+        if (soliditySourceSet.getOptimize()){
+            compileTask.optimize = soliditySourceSet.getOptimize()
+        } else {
+            compileTask.optimize = project.solidity.optimize
+        }
+        if (soliditySourceSet.getOptimizeRunsn()){
+            compileTask.optimizeRuns = soliditySourceSet.getOptimizeRunsn()
+        } else {
+            compileTask.optimizeRuns = project.solidity.optimizeRuns
+        }
         compileTask.prettyJson = project.solidity.prettyJson
         if (soliditySourceSet.getEvmVersion()){
             compileTask.evmVersion = soliditySourceSet.getEvmVersion()
@@ -130,7 +142,11 @@ class SolidityPlugin implements Plugin<Project> {
             compileTask.evmVersion = project.solidity.evmVersion
         }
         compileTask.allowPaths = project.solidity.allowPaths
-        compileTask.ignoreMissing = project.solidity.ignoreMissing
+        if (soliditySourceSet.getIgnoreMissing()){
+            compileTask.ignoreMissing = soliditySourceSet.getIgnoreMissing()
+        } else {
+            compileTask.ignoreMissing = project.solidity.ignoreMissing
+        }
         compileTask.outputs.dir(soliditySourceSet.solidity.destinationDirectory)
         compileTask.description = "Compiles $sourceSet.name Solidity source."
 

--- a/src/main/groovy/org/web3j/solidity/gradle/plugin/SolidityPlugin.groovy
+++ b/src/main/groovy/org/web3j/solidity/gradle/plugin/SolidityPlugin.groovy
@@ -124,7 +124,8 @@ class SolidityPlugin implements Plugin<Project> {
         compileTask.optimize = project.solidity.optimize
         compileTask.optimizeRuns = project.solidity.optimizeRuns
         compileTask.prettyJson = project.solidity.prettyJson
-        compileTask.evmVersion = project.solidity.evmVersion
+//        compileTask.evmVersion = project.solidity.${srcSetName}.evmVersion
+        compileTask.evmVersion = soliditySourceSet.getEvmVersion()
         compileTask.allowPaths = project.solidity.allowPaths
         compileTask.ignoreMissing = project.solidity.ignoreMissing
         compileTask.outputs.dir(soliditySourceSet.solidity.destinationDirectory)

--- a/src/main/groovy/org/web3j/solidity/gradle/plugin/SoliditySourceSet.groovy
+++ b/src/main/groovy/org/web3j/solidity/gradle/plugin/SoliditySourceSet.groovy
@@ -61,4 +61,10 @@ interface SoliditySourceSet {
 
     String NAME = "solidity"
 
+    // New method to set the EVM version for the Solidity compiler
+    void setEvmVersion(EVMVersion evmVersion)
+
+    // New method to get the EVM version for the Solidity compiler
+    EVMVersion getEvmVersion()
+
 }

--- a/src/main/groovy/org/web3j/solidity/gradle/plugin/SoliditySourceSet.groovy
+++ b/src/main/groovy/org/web3j/solidity/gradle/plugin/SoliditySourceSet.groovy
@@ -61,10 +61,24 @@ interface SoliditySourceSet {
 
     String NAME = "solidity"
 
-    // New method to set the EVM version for the Solidity compiler
     void setEvmVersion(EVMVersion evmVersion)
 
-    // New method to get the EVM version for the Solidity compiler
     EVMVersion getEvmVersion()
+
+    void setVersion(String version)
+
+    String getVersion()
+
+    void setOptimize(Boolean optimize)
+
+    Boolean getOptimize()
+
+    void setOptimizeRuns(Integer optimizeRuns)
+
+    Integer getOptimizeRunsn()
+
+    void setIgnoreMissing(Boolean ignoreMissing)
+
+    Boolean getIgnoreMissing()
 
 }

--- a/src/test/groovy/org/web3j/solidity/gradle/plugin/SolidityPluginTest.groovy
+++ b/src/test/groovy/org/web3j/solidity/gradle/plugin/SolidityPluginTest.groovy
@@ -191,9 +191,7 @@ class SolidityPluginTest {
             plugins {
                id 'org.web3j.solidity'
             }
-            solidity {
-                evmVersion = 'ISTANBUL'
-            }
+            
             sourceSets {
                main {
                    solidity {
@@ -204,6 +202,7 @@ class SolidityPluginTest {
                        exclude "openzeppelin/**"
                        exclude "$differentVersionsFolderName/**"
                    }
+                   setEvmVersion("ISTANBUL")
                }
             tasks.named("jar").configure { dependsOn("compileSolidity") }
             }

--- a/src/test/groovy/org/web3j/solidity/gradle/plugin/SolidityPluginTest.groovy
+++ b/src/test/groovy/org/web3j/solidity/gradle/plugin/SolidityPluginTest.groovy
@@ -191,6 +191,44 @@ class SolidityPluginTest {
             plugins {
                id 'org.web3j.solidity'
             }
+            solidity {
+                evmVersion = 'ISTANBUL'
+            }
+            sourceSets {
+               main {
+                   solidity {
+                       exclude "sol5/**"
+                       exclude "eip/**"
+                       exclude "greeter/**"
+                       exclude "common/**"
+                       exclude "openzeppelin/**"
+                       exclude "$differentVersionsFolderName/**"
+                   }
+               }
+            tasks.named("jar").configure { dependsOn("compileSolidity") }
+            }
+        """
+
+        def success = build()
+        assertEquals(SUCCESS, success.task(":compileSolidity").outcome)
+
+        def compiledSolDir = new File(testProjectDir.root, "build/resources/main/solidity")
+        def compiledAbi = new File(compiledSolDir, "MinimalForwarder.abi")
+        assertTrue(compiledAbi.exists())
+
+        def compiledBin = new File(compiledSolDir, "MinimalForwarder.bin")
+        assertTrue(compiledBin.exists())
+
+        def upToDate = build()
+        assertEquals(UP_TO_DATE, upToDate.task(":compileSolidity").outcome)
+    }
+
+    @Test
+    void compileSolidityWithSourceSetsSpecificConfig() {
+        buildFile << """
+            plugins {
+               id 'org.web3j.solidity'
+            }
             
             sourceSets {
                main {
@@ -202,7 +240,10 @@ class SolidityPluginTest {
                        exclude "openzeppelin/**"
                        exclude "$differentVersionsFolderName/**"
                    }
-                   setEvmVersion("ISTANBUL")
+               setEvmVersion('ISTANBUL')
+               setOptimize(true)
+               setOptimizeRuns(200)
+               setVersion('0.8.12')
                }
             tasks.named("jar").configure { dependsOn("compileSolidity") }
             }


### PR DESCRIPTION
### What does this PR do?
Add functionality where user can set different evmVersions, sol version, optimize, optmizeRuns and ignnoreMissing values for different Source Sets

### Where should the reviewer start?
src/main/groovy/org/web3j/solidity/gradle/plugin/SoliditySourceSet.groovy

### Why is it needed?
currently, we can define different sourceSets in web3j solidity gradle plugin, but solidity config for compilation is global and it can be set as different for different source Sets.

## Checklist

- [x] I've read the contribution guidelines.
- [x] I've added tests (if applicable).
- [x] I've added a changelog entry if necessary.