### PR TITLE
Make the 'prettyJson' option work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes
 
-* Fix `prettyJson = true` option
+* Fix `prettyJson = true` option [#75](https://github.com/hyperledger/web3j-solidity-gradle-plugin/pull/75)
 
 ### Features
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 
 ### Bug Fixes
 
-*
+* Fix `prettyJson = true` option
 
 ### Features
 

--- a/src/main/groovy/org/web3j/solidity/gradle/plugin/SolidityCompile.groovy
+++ b/src/main/groovy/org/web3j/solidity/gradle/plugin/SolidityCompile.groovy
@@ -99,7 +99,6 @@ class SolidityCompile extends SourceTask {
 
             if (prettyJson) {
                 options.add('--pretty-json')
-                options.add(options.add("--$OutputComponent.ASM_JSON"))
             }
 
             if (ignoreMissing) {


### PR DESCRIPTION
### What does this PR do?

`options.add(options.add("--$OutputComponent.ASM_JSON"))` contained a duplicated `options.add`, which added `true` to the command line (the return value of `options.add()`). The command fails with: _unrecognized "true"_.

This PR proposes to fix this issue by not implicitly adding the additional `ASM_JSON` output. As  `prettyJson = true` also makes sense in combination with other outputs such as `ABI`.

### Where should the reviewer start?

n/a

### Why is it needed?

`prettyJson = true` is currently not working. It always leads to a broken compiler call.


## Checklist

- [x] I've read the contribution guidelines.
- [ ] I've added tests (if applicable).
- [x] I've added a changelog entry if necessary.